### PR TITLE
Make queen food movement match reference implementation

### DIFF
--- a/games/formic/GameManager.js
+++ b/games/formic/GameManager.js
@@ -328,6 +328,7 @@ define([
 		}
 
 		moveAnt(index, ant, action, rotation) {
+			/* jshint maxcomplexity:15 */ //Complex interactions for a complex game
 			const p = this.offsetPos(ant, ROTATIONS[rotation][action.cell]);
 			if(action.color) {
 				setColourAtI(this.board, p.i, action.color);
@@ -356,7 +357,26 @@ define([
 				ant.y = p.y;
 				ant.i = p.i;
 			}
-			if(ant.type !== QUEEN) {
+			if(ant.type === QUEEN) {
+				for(let i = 0; i < 9; ++ i) {
+					const target = this.antGrid[this.offsetPos(ant, i).i];
+					if(
+						target && target.type !== QUEEN &&
+						target.entry !== ant.entry
+					) {
+						transferFood(target, ant);
+					}
+				}
+				for(let i = 0; i < 9; ++ i) {
+					const target = this.antGrid[this.offsetPos(ant, i).i];
+					if(
+						target && target.type !== QUEEN &&
+						target.entry === ant.entry
+					) {
+						transferFood(target, ant);
+					}
+				}
+			} else {
 				for(let i = 0; i < 9; ++ i) {
 					const target = this.antGrid[this.offsetPos(ant, i).i];
 					if(


### PR DESCRIPTION
This has been extracted from #22, squashed, and created as a new PR to allow discussion.

Before merging this, I would like to see the linter workaround removed. Should be easy to simplify this code once the meaning is clear, but right now I'm struggling to see how it's supposed to behave. Here's how I currently read it:

* An ant moves
* If the ant lands on food, it picks it up
* If the ant is a queen:
  * Look for enemy ants nearby. Each enemy gets to steal 1 food.
  * After all enemy ants have been checked, now look for own-team worker ants. Each worker gets to provide 1 food (since this check happens after all enemy checks, food will never go from a friendly worker to an unfriendly worker in a single step)
* If the ant is not a queen:
  * Look for any queen ants nearby of either team. Either provide or steal food as appropriate.

It seems a bit strange that it checks enemy ants then non-enemy ants for the queen case, but bundles them all together for the worker case. Is this correct behaviour? What does the reference implementation do?