### PR TITLE
Increase battlebots max thinking time to 50ms

### DIFF
--- a/games/battlebots/GameManager.js
+++ b/games/battlebots/GameManager.js
@@ -53,7 +53,7 @@ define([
 		if(Math.round(action) !== action || action < 0 || action > 6) {
 			return 'Invalid action: ' + action;
 		}
-		if(elapsed > 15) {
+		if(elapsed > 50) {
 			return 'Too long to respond: ' + elapsed + 'ms';
 		}
 		return '';


### PR DESCRIPTION
This has been extracted from #22 and created as a new PR to allow discussion.

I'd like to know why this rule was changed. The original value of 15 milliseconds comes directly from the [original question](https://codegolf.stackexchange.com/questions/48353/red-vs-blue-pixel-team-battlebots):

> Your pixel will stay still by default if your code does any of these things:
> - [...]
> - Takes longer than 15 milliseconds to run.

So this change makes the player more lax than the original specification. Also I'm not aware of the time limit being an issue for any entries.